### PR TITLE
Add AsLink for making records of Links

### DIFF
--- a/src/Servant/Generic.hs
+++ b/src/Servant/Generic.hs
@@ -14,6 +14,7 @@ module Servant.Generic
   , AsServerT
   , AsServer
   , AsApi
+  , AsLink
   , ToServant
   , toServant
   , fromServant
@@ -84,6 +85,12 @@ infixl 8 :-
 -- | A type that specifies that an API record contains an API definition. Only useful at type-level.
 data AsApi
 type instance AsApi :- api = api
+
+-- | A type that specifies that an API record contains a set of links.
+--
+-- (Useful since servant 0.12)
+data AsLink
+type instance AsLink :- api = MkLink api
 
 -- | A type that specifies that an API record contains a server implementation.
 data AsServerT (m :: * -> *)


### PR DESCRIPTION
This adds support for generating records that contain links (or functions that generate links).
To be really useful depends on an instance for (:<|>) that I'm adding to servant 0.12 (unreleased). This can be merged ahead of that though, to support single-field records and records in general when used with servant 0.12.